### PR TITLE
Security fix: Update aiohttp to >= 3.14.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,7 @@
 # CVE-2026-42271 (KEV): LiteLLM authenticated command execution via MCP stdio test endpoints
 # Fixed in 1.83.7 - https://github.com/BerriAI/litellm/security/advisories
 litellm>=1.83.7
+
+# CVE-2026-34993 (RHOAIENG-66011): aiohttp arbitrary code execution via CookieJar.load()
+# Fixed in: aiohttp >= 3.14.0
+aiohttp>=3.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@ accelerate==1.13.0
     # via garak
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.0
     # via
+    #   -c constraints.txt
     #   fsspec
     #   litellm
 aiosignal==1.4.0


### PR DESCRIPTION
## Summary
Security fix — see [RHOAIENG-66011](https://redhat.atlassian.net/browse/RHOAIENG-66011) for details.

## Changes
- **Updated**: `constraints.txt` — added `aiohttp>=3.14.0` security floor
- **Updated**: `requirements.txt` — aiohttp bumped `3.13.3 → 3.14.0`

## Validation
```bash
$ grep "^aiohttp==" requirements.txt
aiohttp==3.14.0
```

Fixes RHOAIENG-66011

🤖 Generated with [Claude Code](https://claude.com/claude-code)