### PR TITLE
Security fix: Update urllib3 to >= 2.7.0

### DIFF
--- a/.konflux/ppc64le/requirements.txt
+++ b/.konflux/ppc64le/requirements.txt
@@ -2365,10 +2365,11 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via pandas
-urllib3==2.6.2 \
-    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
-    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -c security-constraints.txt
     #   botocore
     #   kfp
     #   kfp-server-api

--- a/.konflux/s390x/requirements.txt
+++ b/.konflux/s390x/requirements.txt
@@ -2365,10 +2365,11 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via pandas
-urllib3==2.6.2 \
-    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
-    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -c security-constraints.txt
     #   botocore
     #   kfp
     #   kfp-server-api

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -2365,10 +2365,11 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via pandas
-urllib3==2.6.2 \
-    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
-    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -c security-constraints.txt
     #   botocore
     #   kfp
     #   kfp-server-api

--- a/requirements-x86_64.txt
+++ b/requirements-x86_64.txt
@@ -2365,10 +2365,11 @@ tzdata==2025.3 \
     --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
     --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
     # via pandas
-urllib3==2.6.2 \
-    --hash=sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797 \
-    --hash=sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
+    #   -c security-constraints.txt
     #   botocore
     #   kfp
     #   kfp-server-api

--- a/security-constraints.txt
+++ b/security-constraints.txt
@@ -37,3 +37,8 @@ aiohttp>=3.14.0
 # no upper bound), which is within llama-stack's fastapi<1.0,>=0.115.0 constraint.
 starlette>=1.0.1
 fastapi>=0.135.0
+
+# CVE-2026-44431 (RHOAIENG-64536): urllib3 cross-origin redirect header disclosure
+# CVE-2026-44432 (RHOAIENG-63917): urllib3 DoS via excessive decompression
+# Fixed in: urllib3 >= 2.7.0
+urllib3>=2.7.0


### PR DESCRIPTION
## Summary
Security fix — see [RHOAIENG-64536](https://redhat.atlassian.net/browse/RHOAIENG-64536) and [RHOAIENG-63917](https://redhat.atlassian.net/browse/RHOAIENG-63917) for details.

## Changes
- **Updated**: `security-constraints.txt` — added `urllib3>=2.7.0` security floor
- **Updated**: `requirements-x86_64.txt`, `requirements-aarch64.txt`, `.konflux/ppc64le/requirements.txt`, `.konflux/s390x/requirements.txt` — urllib3 bumped `2.6.2 → 2.7.0` (regenerated via pip-compile)

## Validation
```bash
$ grep "^urllib3==" requirements-x86_64.txt
urllib3==2.7.0 \\
```

Fixes RHOAIENG-64536
Fixes RHOAIENG-63917

🤖 Generated with [Claude Code](https://claude.com/claude-code)