### PR TITLE
fix(cve): bump pillow to >= 12.3.0 to address multiple CVEs [rhoai-3.4]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -16,3 +16,10 @@ starlette>=1.0.1
 # CVE-2026-48526 (RHOAIENG-66616): PyJWT: Authentication bypass due to forged JSON Web Tokens
 # Fixed in: pyjwt >= 2.13.0
 pyjwt>=2.13.0
+
+# Pillow (transitive via garak / llama-stack): batch of image/PDF/font parsing flaws
+# CVE-2026-59197, CVE-2026-59199, CVE-2026-59200, CVE-2026-59204, CVE-2026-59205,
+# CVE-2026-54058, CVE-2026-54060, CVE-2026-55379, CVE-2026-55380 (fixed in 12.3.0)
+# CVE-2026-42311 (PSD, potential ACE, fixed in 12.2.0)
+# Fixed in: pillow >= 12.3.0
+pillow>=12.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -406,7 +406,7 @@ pandas==3.0.1
     #   datasets
     #   llama-stack-client
     #   sdg-hub
-pillow==12.1.1
+pillow==12.3.0
     # via garak
 prompt-toolkit==3.0.52
     # via llama-stack-client


### PR DESCRIPTION
## Summary

Bumps **Pillow** to `>= 12.3.0` to remediate a batch of image/PDF/font parsing CVEs. Pillow is a **transitive** dependency (pulled in via `garak` and `llama-stack`); it is not used directly by this provider's source. The change updates the security constraint (`constraints.txt`) and the resolved pin (`requirements.txt`) from `12.1.1` to `12.3.0`.

All listed CVEs are fixed in Pillow 12.3.0 (except CVE-2026-42311, fixed in 12.2.0), so a single floor of `>= 12.3.0` clears the entire batch.

## CVEs addressed

| CVE | Flaw | Jira |
|-----|------|------|
| CVE-2026-59197 | Heap OOB write in `ImageFilter.RankFilter` | RHOAIENG-77766 |
| CVE-2026-59199 | Heap OOB write via near-int32 coords (`paste`/`crop`/`alpha_composite`) | RHOAIENG-77500 |
| CVE-2026-59200 | DoS via crafted FlateDecode PDF stream | RHOAIENG-77535 |
| CVE-2026-59204 | DoS/OOM via crafted tiled JPEG2000 | RHOAIENG-77116 |
| CVE-2026-59205 | Heap corruption in `ImageCms.ImageCmsTransform.apply` | RHOAIENG-77282 |
| CVE-2026-54058 | Memory disclosure/DoS via crafted McIdas AREA image | RHOAIENG-77482 |
| CVE-2026-54060 | DoS via crafted font file (`FontFile.compile`) | RHOAIENG-75306 |
| CVE-2026-55379 | DoS via crafted BDF font file | RHOAIENG-75093 |
| CVE-2026-55380 | DoS via crafted GD 2.x image file | RHOAIENG-75206 |
| CVE-2026-42311 | Memory corruption / potential ACE via malicious PSD file | RHOAIENG-74961 |

## Testing

- `pytest tests` — 356 passed (garak and Pillow are mocked; the provider does not import PIL directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)